### PR TITLE
fix(deps-dev): update micromatch to address security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8178,12 +8178,13 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {


### PR DESCRIPTION
This pull request updates the `micromatch` development dependency from version 4.0.5 to 4.0.8 to address identified security vulnerabilities. The update includes:

- Upgrading `micromatch` from 4.0.5 to 4.0.8
- Updating the `braces` dependency from ^3.0.2 to ^3.0.3
- Adding MIT license information for `micromatch`

These changes ensure that our development environment remains secure and up-to-date with the latest dependency versions.